### PR TITLE
Be able to use a Cookie Jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,44 @@ var jira = new JiraClient({
 // Jira is now authenticted with your account!
 ```
 
+### Cookie Jar
+
+You can also use a Cookie Jar for your request. It could be an easier way to prompt for a login only once, without the
+pain of setting up an OAuth method.
+
+For example, using `though-cookie-filestore`:
+```javascript
+var JiraClient = require('../jira-connector'),
+    FileCookieStore = require('tough-cookie-filestore'),
+
+    request = require('request'),
+    path = require('path');
+
+var jar = request.jar(new FileCookieStore(path.join(__dirname, 'cookies.json')));
+
+// For the first connection
+var jira = new JiraClient( {
+    host: 'jenjinstudios.atlassian.net',
+    basic_auth: {
+        username: 'SirUserOfName',
+        password: 'Password123'
+    },
+    cookie_jar: jar
+});
+
+// For the following connections
+var jira = new JiraClient( {
+    host: 'jenjinstudios.atlassian.net',
+    cookie_jar: jar
+});
+```
+
+In this example, all your cookies are save in a file, `cookies.json`. Currently, the file **MUST** exist, it's a 
+limitation from `though-cookie-filestore`...
+
+You can now only use the Cookie Jar for all the following request, as long as the file exists and the cookie
+is still valid!
+
 ## Supported API Calls
 
 * application-properties (/rest/api/2/application-properties)

--- a/index.js
+++ b/index.js
@@ -113,6 +113,7 @@ var workflowScheme = require('./api/workflowScheme');
  * @param {string} [config.oauth.token] The VERIFIED token used to connect to the Jira API.  MUST be included if using
  *     OAuth.
  * @param {string} [config.oauth.token_secret] The secret for the above token.  MUST be included if using Oauth.
+ * @param {CookieJar} [config.cookie_jar] The CookieJar to use for every requests.
  */
 var JiraClient = module.exports = function (config) {
     if(!config.host) {
@@ -149,9 +150,10 @@ var JiraClient = module.exports = function (config) {
             pass: config.basic_auth.password
         };
 
-    } else if (config.cookie_jar) {
-        request = request.defaults({ jar: config.cookie_jar });
+    }
 
+    if (config.cookie_jar) {
+        this.cookie_jar = config.cookie_jar;
     }
 
     this.issue = new issue(this);
@@ -233,6 +235,9 @@ var JiraClient = module.exports = function (config) {
             options.oauth = this.oauthConfig;
         } else if (this.basic_auth) {
             options.auth = this.basic_auth;
+        }
+        if (this.cookie_jar) {
+            options.jar = this.cookie_jar;
         }
         request(options, function (err, response, body) {
             if (err || response.statusCode.toString()[0] != 2) {

--- a/index.js
+++ b/index.js
@@ -149,6 +149,9 @@ var JiraClient = module.exports = function (config) {
             pass: config.basic_auth.password
         };
 
+    } else if (config.cookie_jar) {
+        request = request.defaults({ jar: config.cookie_jar });
+
     }
 
     this.issue = new issue(this);


### PR DESCRIPTION
In this small PR, I added the possibility to use a Cookie Jar for all the requests.

I find it convenient since when using `jira-connector`, one can prompt the user only once for its username & password, and then store the cookie in a file for example.

All the following requests would just use the created cookie. Like that, the user won't have to store its password, are re-type it everytime, or the developer won't have to go through the pain of implementing an OAuth Authentication.

I also updated the README with an example, and the JS-DocBlock :)