### PR TITLE
Add Base64 basic_auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,29 @@ var jira = new JiraClient( {
 });
 ```
 
+
+### Basic Authentication (Base64)
+
+Also not recommended, but slightly better than the above; it will require you to provide a Base64 encoded username
+and password (a Base64 encoding in the format of "username:password") each time you connect to the Jira instance.
+
+More examples [here](https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-example-basic-authentication).
+
+Example:
+
+```javascript
+var JiraClient = require('jira-connector');
+
+var jira = new JiraClient( {
+    host: 'jenjinstudios.atlassian.net',
+    basic_auth: {
+        base64: 'U2lyVXNlck9mTmFtZTpQYXNzd29yZDEyMw=='
+    }
+});
+
+// Base64 encoding of 'SirUserOfName:Password123'
+```
+
 ### OAuth Authentication
 
 This should be the preferred method of authentication; it is more secure and does not require disclosing
@@ -219,7 +242,7 @@ var jira = new JiraClient( {
 });
 ```
 
-In this example, all your cookies are save in a file, `cookies.json`. Currently, the file **MUST** exist, it's a 
+In this example, all your cookies are save in a file, `cookies.json`. Currently, the file **MUST** exist, it's a
 limitation from `though-cookie-filestore`...
 
 You can now only use the Cookie Jar for all the following request, as long as the file exists and the cookie

--- a/index.js
+++ b/index.js
@@ -139,17 +139,22 @@ var JiraClient = module.exports = function (config) {
         this.oauthConfig.signature_method = 'RSA-SHA1';
 
     } else if (config.basic_auth) {
-        if (!config.basic_auth.username) {
-            throw new Error(errorStrings.NO_USERNAME_ERROR);
-        } else if (!config.basic_auth.password) {
-            throw new Error(errorStrings.NO_PASSWORD_ERROR);
+        if (config.basic_auth.base64) {
+            this.basic_auth = {
+              base64: config.base64
+            }
+        } else {
+            if (!config.basic_auth.username) {
+                throw new Error(errorStrings.NO_USERNAME_ERROR);
+            } else if (!config.basic_auth.password) {
+                throw new Error(errorStrings.NO_PASSWORD_ERROR);
+            }
+
+            this.basic_auth = {
+                user: config.basic_auth.username,
+                pass: config.basic_auth.password
+            };
         }
-
-        this.basic_auth = {
-            user: config.basic_auth.username,
-            pass: config.basic_auth.password
-        };
-
     }
 
     if (config.cookie_jar) {
@@ -234,7 +239,13 @@ var JiraClient = module.exports = function (config) {
         if (this.oauthConfig) {
             options.oauth = this.oauthConfig;
         } else if (this.basic_auth) {
-            options.auth = this.basic_auth;
+            if (this.basic_auth.base64) {
+              options.headers = {
+                Authorization: 'Basic ' + this.basic_auth.base64
+              }
+            } else {
+              options.auth = this.basic_auth;
+            }
         }
         if (this.cookie_jar) {
             options.jar = this.cookie_jar;
@@ -255,4 +266,3 @@ var JiraClient = module.exports = function (config) {
 JiraClient.oauth_util = require('./lib/oauth_util');
 
 exports.oauth_util = oauth_util;
-

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ var JiraClient = module.exports = function (config) {
     } else if (config.basic_auth) {
         if (config.basic_auth.base64) {
             this.basic_auth = {
-              base64: config.base64
+              base64: config.basic_auth.base64
             }
         } else {
             if (!config.basic_auth.username) {


### PR DESCRIPTION
Thought this would be a worthy addition (I'm currently using it to base64 my creds with shared repo because I just don't feel like setting up oauth on my project at the moment nor sharing my creds openly in a file).

https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-example-basic-authentication